### PR TITLE
adding Eclipse files/dirs to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@
 .idea
 build 
 .DS_Store
+
+# eclipse IDE related dirs/files to omit
+.classpath
+.project
+.settings
+bin


### PR DESCRIPTION
I have just started going through your Gradle tutorial. I forked your repo and started reviewing the code in Eclipse when git was seeing my Eclipse meta files. So I thought I'd share the .gitignore edits I made to hide the Eclipse files.
